### PR TITLE
Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/src/main/java/org/cafesip/sipunit/EventSubscriber.java
+++ b/src/main/java/org/cafesip/sipunit/EventSubscriber.java
@@ -1502,7 +1502,7 @@ public class EventSubscriber implements MessageListener, SipActionObject {
     initErrorInfo();
 
     synchronized (this) {
-      if (reqEvents.size() == 0) {
+      if (reqEvents.isEmpty()) {
         try {
           LOG.trace("about to block, waiting");
           this.wait(timeout);
@@ -1516,7 +1516,7 @@ public class EventSubscriber implements MessageListener, SipActionObject {
       }
 
       LOG.trace("either we got the request, or timed out");
-      if (reqEvents.size() == 0) {
+      if (reqEvents.isEmpty()) {
         String err =
             "*** NOTIFY REQUEST ERROR ***  (" + targetUri
                 + ") - The maximum amount of time to wait for a NOTIFY message has elapsed.";
@@ -1554,7 +1554,7 @@ public class EventSubscriber implements MessageListener, SipActionObject {
   protected EventObject waitResponse(long timeout) {
     synchronized (responseBlock) {
       LinkedList<EventObject> events = transaction.getEvents();
-      if (events.size() == 0) {
+      if (events.isEmpty()) {
         try {
           LOG.trace("about to block, waiting");
           responseBlock.waitForEvent(timeout);
@@ -1569,7 +1569,7 @@ public class EventSubscriber implements MessageListener, SipActionObject {
 
       LOG.trace("either we got the response, or timed out");
 
-      if (events.size() == 0) {
+      if (events.isEmpty()) {
         setReturnCode(SipSession.TIMEOUT_OCCURRED);
         setErrorMessage("The maximum amount of time to wait for a response message has elapsed.");
         return null;

--- a/src/main/java/org/cafesip/sipunit/SipPhone.java
+++ b/src/main/java/org/cafesip/sipunit/SipPhone.java
@@ -1065,7 +1065,7 @@ public class SipPhone extends SipSession implements SipActionObject, RequestList
     this.removeRequestListener(Request.NOTIFY, this);
 
     // drop calls
-    while (callList.size() > 0) {
+    while (!callList.isEmpty()) {
       ((SipCall) callList.get(0)).dispose();
     }
 

--- a/src/main/java/org/cafesip/sipunit/SipSession.java
+++ b/src/main/java/org/cafesip/sipunit/SipSession.java
@@ -1028,7 +1028,7 @@ public class SipSession implements SipListener, SipActionObject {
 
     synchronized (trans.getBlock()) {
       LinkedList<EventObject> events = trans.getEvents();
-      if (events.size() == 0) {
+      if (events.isEmpty()) {
         try {
           trans.getBlock().waitForEvent(timeout);
         } catch (Exception ex) {
@@ -1039,7 +1039,7 @@ public class SipSession implements SipListener, SipActionObject {
         }
       }
 
-      if (events.size() == 0) {
+      if (events.isEmpty()) {
         setReturnCode(TIMEOUT_OCCURRED);
         setErrorMessage("The maximum amount of time to wait for a response message has elapsed.");
         return null;
@@ -1101,7 +1101,7 @@ public class SipSession implements SipListener, SipActionObject {
     initErrorInfo();
 
     synchronized (reqBlock) {
-      if (reqEvents.size() == 0) {
+      if (reqEvents.isEmpty()) {
         try {
           LOG.trace("about to block, waiting");
           reqBlock.waitForEvent(timeout);
@@ -1115,7 +1115,7 @@ public class SipSession implements SipListener, SipActionObject {
       }
 
       LOG.trace("either we got the request, or timed out");
-      if (reqEvents.size() == 0) {
+      if (reqEvents.isEmpty()) {
         setReturnCode(TIMEOUT_OCCURRED);
         setErrorMessage("The maximum amount of time to wait for a request message has elapsed.");
         return null;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
Ayman Abdelghany.
