### PR TITLE
use Java collection interfaces rather than specific implementation

### DIFF
--- a/src/main/java/org/cafesip/sipunit/EventSubscriber.java
+++ b/src/main/java/org/cafesip/sipunit/EventSubscriber.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.EventObject;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 
 import javax.sip.Dialog;
 import javax.sip.RequestEvent;
@@ -387,7 +388,7 @@ public class EventSubscriber implements MessageListener, SipActionObject {
         MaxForwardsHeader maxForwards =
             hdrFactory.createMaxForwardsHeader(SipPhone.MAX_FORWARDS_DEFAULT);
 
-        ArrayList<ViaHeader> viaHeaders = parent.getViaHeaders();
+        List<ViaHeader> viaHeaders = parent.getViaHeaders();
 
         req =
             parent.getMessageFactory().createRequest(requestUri, method, callId, requestCSeq,
@@ -1395,7 +1396,7 @@ public class EventSubscriber implements MessageListener, SipActionObject {
 
   // if returns null, returnCode and errorMessage already set
   protected Response createNotifyResponse(RequestEvent request, int status, String reason,
-      ArrayList<Header> additionalHeaders) {
+      List<Header> additionalHeaders) {
     // when used internally - WATCH OUT - retcode, errorMessage initialized here
     initErrorInfo();
 

--- a/src/main/java/org/cafesip/sipunit/PresenceNotifySender.java
+++ b/src/main/java/org/cafesip/sipunit/PresenceNotifySender.java
@@ -528,7 +528,7 @@ public class PresenceNotifySender implements MessageListener {
               .createMaxForwardsHeader(SipPhone.MAX_FORWARDS_DEFAULT);
           req.setHeader(max_forwards);
 
-          ArrayList<ViaHeader> via_headers = phone.getViaHeaders();
+          List<ViaHeader> via_headers = phone.getViaHeaders();
           Iterator<ViaHeader> i = via_headers.iterator();
           while (i.hasNext()) {
             req.addHeader((Header) i.next());

--- a/src/main/java/org/cafesip/sipunit/PresenceSubscriber.java
+++ b/src/main/java/org/cafesip/sipunit/PresenceSubscriber.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 
 import javax.sip.header.AcceptHeader;
 import javax.sip.header.ContentTypeHeader;
@@ -196,7 +197,7 @@ public class PresenceSubscriber extends EventSubscriber {
           dev.setStatusExtensions(t.getStatus().getAny());
           dev.setTimestamp(t.getTimestamp());
 
-          ArrayList<PresenceNote> notes = new ArrayList<>();
+          List<PresenceNote> notes = new ArrayList<>();
           if (t.getNote() != null) {
             Iterator<?> j = t.getNote().iterator();
             while (j.hasNext()) {
@@ -264,7 +265,7 @@ public class PresenceSubscriber extends EventSubscriber {
    * 
    * @return An ArrayList containing zero or more Object.
    */
-  public ArrayList<Object> getPresenceExtensions() {
+  public List<Object> getPresenceExtensions() {
     return new ArrayList<>(presenceExtensions);
   }
 

--- a/src/main/java/org/cafesip/sipunit/SipAssert.java
+++ b/src/main/java/org/cafesip/sipunit/SipAssert.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.ListIterator;
 import java.util.concurrent.Callable;
 
@@ -330,7 +331,7 @@ public class SipAssert {
 
   private static boolean responseReceived(int statusCode, String method, long sequenceNumber,
       MessageListener obj) {
-    ArrayList<SipResponse> responses = obj.getAllReceivedResponses();
+    List<SipResponse> responses = obj.getAllReceivedResponses();
 
     Iterator<SipResponse> i = responses.iterator();
     while (i.hasNext()) {
@@ -444,7 +445,7 @@ public class SipAssert {
   }
 
   private static boolean requestReceived(String method, MessageListener obj) {
-    ArrayList<SipRequest> requests = obj.getAllReceivedRequests();
+    List<SipRequest> requests = obj.getAllReceivedRequests();
 
     Iterator<SipRequest> i = requests.iterator();
     while (i.hasNext()) {
@@ -475,7 +476,7 @@ public class SipAssert {
   }
 
   private static boolean requestReceived(String method, long sequenceNumber, MessageListener obj) {
-    ArrayList<SipRequest> requests = obj.getAllReceivedRequests();
+    List<SipRequest> requests = obj.getAllReceivedRequests();
 
     Iterator<SipRequest> i = requests.iterator();
     while (i.hasNext()) {

--- a/src/main/java/org/cafesip/sipunit/SipCall.java
+++ b/src/main/java/org/cafesip/sipunit/SipCall.java
@@ -835,7 +835,7 @@ public class SipCall implements SipActionObject, MessageListener {
         MaxForwardsHeader max_forwards =
             hdr_factory.createMaxForwardsHeader(SipPhone.MAX_FORWARDS_DEFAULT);
 
-        ArrayList<ViaHeader> via_headers = parent.getViaHeaders();
+        List<ViaHeader> via_headers = parent.getViaHeaders();
 
         msg = parent.getMessageFactory().createRequest(request_uri, method, callId, cseq,
             from_header, to_header, via_headers, max_forwards);
@@ -1606,7 +1606,7 @@ public class SipCall implements SipActionObject, MessageListener {
       MaxForwardsHeader max_forwards =
           hdr_factory.createMaxForwardsHeader(SipPhone.MAX_FORWARDS_DEFAULT);
 
-      ArrayList<ViaHeader> via_headers = parent.getViaHeaders();
+      List<ViaHeader> via_headers = parent.getViaHeaders();
 
       Request msg = parent.getMessageFactory().createRequest(request_uri, method, callId, cseq,
           from_header, to_header, via_headers, max_forwards);
@@ -2971,7 +2971,7 @@ public class SipCall implements SipActionObject, MessageListener {
    * @return SipResponse object or null, if not found.
    */
   public SipResponse findMostRecentResponse(int statusCode) {
-    ArrayList<SipResponse> responses = getAllReceivedResponses();
+    List<SipResponse> responses = getAllReceivedResponses();
 
     ListIterator<SipResponse> i = responses.listIterator(responses.size());
     while (i.hasPrevious()) {

--- a/src/main/java/org/cafesip/sipunit/SipPhone.java
+++ b/src/main/java/org/cafesip/sipunit/SipPhone.java
@@ -278,7 +278,7 @@ public class SipPhone extends SipSession implements SipActionObject, RequestList
         }
       }
 
-      ArrayList<ViaHeader> via_headers = getViaHeaders();
+      List<ViaHeader> via_headers = getViaHeaders();
 
       Request msg = parent.getMessageFactory().createRequest(requestUri, method, callid_header,
           cseq, from_header, to_header, via_headers, max_forwards);
@@ -294,10 +294,10 @@ public class SipPhone extends SipSession implements SipActionObject, RequestList
       // include any auth information for this User Agent's registration
       // if any exists
 
-      LinkedHashMap<String, AuthorizationHeader> auth_list =
+      Map<String, AuthorizationHeader> auth_list =
           getAuthorizations().get(myRegistrationId);
       if (auth_list != null) {
-        ArrayList<AuthorizationHeader> auth_headers =
+        List<AuthorizationHeader> auth_headers =
             new ArrayList<>(auth_list.values());
         Iterator<AuthorizationHeader> i = auth_headers.iterator();
         while (i.hasNext()) {
@@ -579,7 +579,7 @@ public class SipPhone extends SipSession implements SipActionObject, RequestList
 
     // find the list of cached AuthorizationHeaders for this call (Call-ID)
     String call_id = ((CallIdHeader) req_msg.getHeader(CallIdHeader.NAME)).getCallId();
-    LinkedHashMap<String, AuthorizationHeader> authorization_list =
+    Map<String, AuthorizationHeader> authorization_list =
         getAuthorizations().get(call_id);
 
     if (authorization_list == null) {
@@ -1155,7 +1155,7 @@ public class SipPhone extends SipSession implements SipActionObject, RequestList
   /**
    * @return Returns the authorizations.
    */
-  protected Hashtable<String, LinkedHashMap<String, AuthorizationHeader>> getAuthorizations() {
+  protected Map<String, LinkedHashMap<String, AuthorizationHeader>> getAuthorizations() {
     return authorizations;
   }
 
@@ -1168,9 +1168,9 @@ public class SipPhone extends SipSession implements SipActionObject, RequestList
   }
 
   protected void addAuthorizations(String call_id, Request msg) {
-    LinkedHashMap<String, AuthorizationHeader> auth_list = getAuthorizations().get(call_id);
+    Map<String, AuthorizationHeader> auth_list = getAuthorizations().get(call_id);
     if (auth_list != null) {
-      ArrayList<AuthorizationHeader> auth_headers =
+      List<AuthorizationHeader> auth_headers =
           new ArrayList<>(auth_list.values());
       Iterator<AuthorizationHeader> i = auth_headers.iterator();
       while (i.hasNext()) {
@@ -1309,7 +1309,7 @@ public class SipPhone extends SipSession implements SipActionObject, RequestList
   private void distributeEventError(String err)
   // to all the Subscriptions - test program will need to see the error
   {
-    ArrayList<EventSubscriber> subscriptions =
+    List<EventSubscriber> subscriptions =
         new ArrayList<EventSubscriber>(getBuddyList().values());
     subscriptions.addAll(new ArrayList<>(getRetiredBuddies().values()));
     subscriptions.addAll(getRefererList());
@@ -1622,7 +1622,7 @@ public class SipPhone extends SipSession implements SipActionObject, RequestList
    * @return a Hashtable of zero or more entries, where the key = URI of the buddy, value =
    *         PresenceSubscriber object.
    */
-  public Hashtable<String, PresenceSubscriber> getBuddyList() {
+  public Map<String, PresenceSubscriber> getBuddyList() {
     return new Hashtable<>(buddyList);
   }
 
@@ -1639,7 +1639,7 @@ public class SipPhone extends SipSession implements SipActionObject, RequestList
    * @return a Hashtable of zero or more entries, where the key = URI of the user, value =
    *         PresenceSubscriber object.
    */
-  public Hashtable<String, PresenceSubscriber> getRetiredBuddies() {
+  public Map<String, PresenceSubscriber> getRetiredBuddies() {
     return new Hashtable<>(buddyTerminatedList);
   }
 

--- a/src/main/java/org/cafesip/sipunit/SipResponse.java
+++ b/src/main/java/org/cafesip/sipunit/SipResponse.java
@@ -17,6 +17,7 @@
 package org.cafesip.sipunit;
 
 import java.util.HashMap;
+import java.util.Map;
 import javax.sip.ResponseEvent;
 import javax.sip.message.Response;
 
@@ -158,7 +159,7 @@ public class SipResponse extends SipMessage {
    * Comment for <code>statusCodeDescription</code> This map yields a reason phrase, given a SIP
    * network response message status code.
    */
-  public static HashMap<Integer, String> statusCodeDescription = new HashMap<>();
+  public static Map<Integer, String> statusCodeDescription = new HashMap<>();
 
   static {
     // PROVISIONAL (1xx)

--- a/src/main/java/org/cafesip/sipunit/SipSession.java
+++ b/src/main/java/org/cafesip/sipunit/SipSession.java
@@ -28,6 +28,8 @@ import java.util.EventObject;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.StringTokenizer;
 
 import javax.sip.ClientTransaction;
@@ -185,7 +187,7 @@ public class SipSession implements SipListener, SipActionObject {
 
   private BlockObject respBlock = new BlockObject();
 
-  private HashMap<String, ArrayList<RequestListener>> requestListeners = new HashMap<>();
+  private Map<String, ArrayList<RequestListener>> requestListeners = new HashMap<>();
 
   // key = String request method, value = ArrayList of RequestListener
 
@@ -409,7 +411,7 @@ public class SipSession implements SipListener, SipActionObject {
 
     // check for listener handling
     synchronized (requestListeners) {
-      ArrayList<RequestListener> listeners = requestListeners.get(req_msg.getMethod());
+      List<RequestListener> listeners = requestListeners.get(req_msg.getMethod());
       if (listeners != null) {
         Iterator<RequestListener> i = listeners.iterator();
         while (i.hasNext()) {
@@ -1403,7 +1405,7 @@ public class SipSession implements SipListener, SipActionObject {
     }
   }
 
-  protected ArrayList<Header> toHeader(ArrayList<String> strings) throws Exception {
+  protected ArrayList<Header> toHeader(List<String> strings) throws Exception {
     if (strings == null) {
       return null;
     }
@@ -1516,8 +1518,8 @@ public class SipSession implements SipListener, SipActionObject {
     return sendReply(transaction, response);
   }
 
-  protected void putElements(Message message, ArrayList<Header> additionalHeaders,
-      ArrayList<Header> replaceHeaders, String body) throws Exception {
+  protected void putElements(Message message, List<Header> additionalHeaders,
+                             List<Header> replaceHeaders, String body) throws Exception {
     // check for additional headers and body to add
     if (additionalHeaders != null) {
       Iterator<Header> i = additionalHeaders.iterator();
@@ -1855,7 +1857,7 @@ public class SipSession implements SipListener, SipActionObject {
     // multiple listeners per method
 
     synchronized (requestListeners) {
-      ArrayList<RequestListener> listeners = requestListeners.get(requestMethod);
+      List<RequestListener> listeners = requestListeners.get(requestMethod);
       if (listeners != null) {
         listeners.remove(listener);
         if (listeners.isEmpty()) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
Ayman Abdelghany.
