### PR TITLE
Add support for multiple request matching strategies when processing NOTIFY requests

### DIFF
--- a/src/main/java/org/cafesip/sipunit/processing/RequestProcessingResult.java
+++ b/src/main/java/org/cafesip/sipunit/processing/RequestProcessingResult.java
@@ -1,0 +1,38 @@
+package org.cafesip.sipunit.processing;
+
+/**
+ * Contains provisional data on whether a request event was accepted by any {@link RequestProcessingStrategy} and if
+ * that processing step was successful.
+ * <p>
+ * Created by TELES AG on 15/01/2018.
+ *
+ * @see RequestProcessor
+ */
+public class RequestProcessingResult {
+
+	private final boolean isProcessed;
+	private final boolean isSuccessful;
+
+	/**
+	 * @param isProcessed If the input was accepted and processed
+	 * @param isSuccessful If the processing result was successful
+	 */
+	public RequestProcessingResult(boolean isProcessed, boolean isSuccessful) {
+		this.isProcessed = isProcessed;
+		this.isSuccessful = isSuccessful;
+	}
+
+	/**
+	 * @return True if any strategy was able to accept the input of the request processor
+	 */
+	public boolean isProcessed() {
+		return isProcessed;
+	}
+
+	/**
+	 * @return True if the accepting strategy was able to successfully process the input of the request processor
+	 */
+	public boolean isSuccessful() {
+		return isSuccessful;
+	}
+}

--- a/src/main/java/org/cafesip/sipunit/processing/RequestProcessingStrategy.java
+++ b/src/main/java/org/cafesip/sipunit/processing/RequestProcessingStrategy.java
@@ -1,0 +1,62 @@
+package org.cafesip.sipunit.processing;
+
+import org.cafesip.sipunit.SipSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sip.RequestEvent;
+import javax.sip.SipListener;
+
+/**
+ * The request matching strategy is used within every {@link SipListener} subclass which is bound to process an incoming
+ * request.
+ * In order to provide multiple ways of accepting a request from various sources, we introduce this type to provide an
+ * unified way to determine if a request fits a criterion for it to be accepted and processed within a session.
+ * <p>
+ * Created by TELES AG on 12/01/2018.
+ *
+ * @see RequestProcessor
+ * @see SipSession#processRequest(RequestEvent)
+ */
+public abstract class RequestProcessingStrategy<ReceiverType extends SipListener> {
+
+	protected static final Logger LOG = LoggerFactory.getLogger(RequestProcessingStrategy.class);
+
+	private final boolean multipleInstanceAllowed;
+
+	/**
+	 * Initialize this strategy with multiple instances of this class allowed to be present in {@link RequestProcessor}
+	 */
+	public RequestProcessingStrategy() {
+		this(true);
+	}
+
+	/**
+	 * Initialize this strategy with option of multiple instances of this class to be present in {@link RequestProcessor}
+	 *
+	 * @param multipleInstanceAllowed If set to true, the processor will allow multiple instances of this class. Otherwise,
+	 *                                any additional instances will not be added to the processor, and will be treated as
+	 *                                a localized singleton.
+	 */
+	public RequestProcessingStrategy(boolean multipleInstanceAllowed) {
+		this.multipleInstanceAllowed = multipleInstanceAllowed;
+	}
+
+	/**
+	 * @return If true, the matcher will allow multiple instances of this class. Otherwise, any additional instances
+	 * will not be added to the processor, and will be treated as a localized singleton.
+	 */
+	public final boolean multipleInstanceAllowed() {
+		return multipleInstanceAllowed;
+	}
+
+	/**
+	 * Determines if the inbound request is processed according to the criterion defined by this strategy.
+	 *
+	 * @param requestEvent The inbound request event
+	 * @param receiver     The governing receiver handler which received the request through its {@link org.cafesip.sipunit.SipStack}
+	 * @return The result of the processing. A request may be accepted, but it may not be successful. If the request is accepted,
+	 * no other strategies in the governing processor will execute.
+	 */
+	public abstract RequestProcessingResult processRequestEvent(final RequestEvent requestEvent, final ReceiverType receiver);
+}

--- a/src/main/java/org/cafesip/sipunit/processing/RequestProcessor.java
+++ b/src/main/java/org/cafesip/sipunit/processing/RequestProcessor.java
@@ -1,0 +1,216 @@
+package org.cafesip.sipunit.processing;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sip.RequestEvent;
+import javax.sip.SipListener;
+import javax.sip.message.Request;
+import java.util.*;
+
+/**
+ * This class takes care that the inbound requests received by a governing {@link SipListener} subclass are tested
+ * against a configurable list of available strategies. The {@link RequestProcessingStrategy} instances which this class
+ * manages are in charge of testing an inbound SIP {@link Request} and providing feedback if the strategy was able to
+ * process the request successfully. The semantics of the (result of) processing is at the discretion of the implementing
+ * strategy.
+ * <p>
+ * The request processor additionally manages that the request processing strategies do not produce side effects when being
+ * mutated, and provides concurrent access to the strategy handling mechanism. The default strategies which are provided by
+ * this class on instantiation are specified with the dedicated constructor.
+ * <p>
+ * Created by TELES AG on 12/01/2018.
+ *
+ * @see RequestProcessingStrategy
+ */
+public class RequestProcessor<ReceiverType extends SipListener> {
+
+	protected static final Logger LOG = LoggerFactory.getLogger(RequestProcessor.class);
+
+	/**
+	 * Request processing strategies process an incoming {@link Request} for the governing client after receiving
+	 * the request through the stack. This class is initialized with a subset of initial strategies.
+	 * The user of this library may add additional processing strategies in order to add additional processing options.
+	 */
+	private final List<RequestProcessingStrategy<ReceiverType>> availableStrategies =
+			Collections.synchronizedList(new ArrayList<RequestProcessingStrategy<ReceiverType>>());
+
+	/**
+	 * Initialize this instance with the provided initial strategies
+	 *
+	 * @param initialStrategies Initial strategies which should be added to the instance
+	 * @see RequestProcessor#add(RequestProcessingStrategy)
+	 */
+	public RequestProcessor(final RequestProcessingStrategy<ReceiverType>... initialStrategies) {
+		this(Arrays.asList(initialStrategies));
+	}
+
+	/**
+	 * Initialize this instance with the provided initial strategies
+	 *
+	 * @param initialStrategies Initial strategies which should be added to the instance
+	 * @see RequestProcessor#add(RequestProcessingStrategy)
+	 */
+	public RequestProcessor(final List<RequestProcessingStrategy<ReceiverType>> initialStrategies) {
+		synchronized (availableStrategies) {
+			for (RequestProcessingStrategy<ReceiverType> strategy : initialStrategies) {
+				add(strategy);
+			}
+		}
+	}
+
+	/**
+	 * Run all configured strategies in this matcher and determine if the request matches any configured criterion. The
+	 * processor will execute every strategy in the available strategy list until the first strategy reports that the
+	 * processing was successful.
+	 *
+	 * @param requestEvent The request being tested for a processing success with the available strategies
+	 * @param receiver     The governing object which received the request
+	 * @return Result denoting if the request has been processed by any configured strategy, and if it was processed
+	 * successfully
+	 */
+	public RequestProcessingResult processRequestEvent(final RequestEvent requestEvent, final ReceiverType receiver) {
+		RequestProcessingResult requestProcessingResult = new RequestProcessingResult(false, false);
+
+		synchronized (availableStrategies) {
+			Iterator<RequestProcessingStrategy<ReceiverType>> iterator = availableStrategies.iterator();
+
+			// If we find a match, then the other strategies will not execute
+			while (!requestProcessingResult.isProcessed() && iterator.hasNext()) {
+				RequestProcessingStrategy strategy = iterator.next();
+				requestProcessingResult = strategy.processRequestEvent(requestEvent, receiver);
+
+				if(requestProcessingResult == null){
+					LOG.warn("Request processing strategy " + strategy.getClass().getName() + " returned null");
+
+					requestProcessingResult = new RequestProcessingResult(false, false);
+				}
+			}
+		}
+		return requestProcessingResult;
+	}
+
+	/**
+	 * Add the strategy to be used in request processing in this processor. If the strategy is not permitted to add multiple
+	 * instances and an existing instance of the same strategy class is present in the processor, it will not be added.
+	 * Otherwise, the strategy will be added per the collection add behavior contract.
+	 *
+	 * @param requestProcessingStrategy The added request processing strategy
+	 * @return If the request processing strategy was successfully added to the list of strategies used by this class
+	 * @see List#add(Object)
+	 */
+	public boolean add(RequestProcessingStrategy<ReceiverType> requestProcessingStrategy) {
+		assertNotNull(requestProcessingStrategy);
+
+		synchronized (availableStrategies) {
+			boolean permittedToAddAdditionalInstances = requestProcessingStrategy.multipleInstanceAllowed() ||
+					!contains(requestProcessingStrategy.getClass());
+			return permittedToAddAdditionalInstances && availableStrategies.add(requestProcessingStrategy);
+		}
+	}
+
+	/**
+	 * Removes the instance of the specified request processing strategy
+	 *
+	 * @param requestProcessingStrategy The strategy that needs to be removed by its reference in the request processor
+	 * @return True if the specified instance of the searched strategy has been removed, false otherwise
+	 * @see List#remove(Object)
+	 */
+	public boolean remove(RequestProcessingStrategy<ReceiverType> requestProcessingStrategy) {
+		assertNotNull(requestProcessingStrategy);
+
+		synchronized (availableStrategies) {
+			if (availableStrategies.contains(requestProcessingStrategy) && availableStrategies.size() == 1) {
+				throw new IllegalArgumentException("Cannot remove only remaining strategy");
+			}
+
+			return availableStrategies.remove(requestProcessingStrategy);
+		}
+	}
+
+	/**
+	 * Removes any existing {@link RequestProcessingStrategy} defined by the searched class in the strategy list.
+	 * If this is the only strategy in the strategy list before removal, the strategy list will be set to default,
+	 * i.e. be reset with the default configured strategies.
+	 *
+	 * @param searchedClass The class that needs to be removed by its type in the request processor
+	 * @return True if any instance of the searched strategy has been removed, false otherwise
+	 */
+	public boolean remove(Class<? extends RequestProcessingStrategy<ReceiverType>> searchedClass) {
+		assertNotNull(searchedClass);
+		boolean isRemoved = false;
+
+		synchronized (availableStrategies) {
+			Iterator<RequestProcessingStrategy<ReceiverType>> it = availableStrategies.iterator();
+
+			while (it.hasNext()) {
+				RequestProcessingStrategy current = it.next();
+
+				if (current.getClass().equals(searchedClass)) {
+					if (availableStrategies.size() == 1) {
+						throw new IllegalArgumentException("Cannot remove only remaining strategy");
+					}
+
+					isRemoved = true;
+					it.remove();
+				}
+			}
+		}
+
+		return isRemoved;
+	}
+
+	/**
+	 * Check if any existing {@link RequestProcessingStrategy<ReceiverType>} defined by the searched class is present in the configured
+	 * strategy list.
+	 *
+	 * @param searchedClass The class whose direct instances will be searched for in the request class
+	 * @return True if any instance of the searched strategy has been found, false otherwise
+	 */
+	public boolean contains(Class<? extends RequestProcessingStrategy> searchedClass) {
+		assertNotNull(searchedClass);
+
+		synchronized (availableStrategies) {
+			for (RequestProcessingStrategy requestProcessingStrategy : availableStrategies) {
+				if (requestProcessingStrategy.getClass().equals(searchedClass)) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if the {@link RequestProcessingStrategy<ReceiverType>} is added to this instance (by reference).
+	 *
+	 * @return True if the specified instance of the searched strategy has been found, false otherwise
+	 * @see List#contains(Object)
+	 */
+	public boolean contains(RequestProcessingStrategy<ReceiverType> requestProcessingStrategy) {
+		assertNotNull(requestProcessingStrategy);
+
+		return availableStrategies.contains(requestProcessingStrategy);
+	}
+
+	/**
+	 * @return A list of available strategies for incoming requests which this instance uses to process the inbound
+	 * request. This list is unmodifiable and synchronized and will be updated with each change.
+	 * @see Collections#synchronizedCollection(Collection)
+	 */
+	public List<RequestProcessingStrategy<ReceiverType>> getAvailableStrategies() {
+		return Collections.unmodifiableList(availableStrategies);
+	}
+
+	private void assertNotNull(RequestProcessingStrategy<ReceiverType> requestProcessingStrategy) {
+		if(requestProcessingStrategy == null){
+			throw new IllegalArgumentException("Request processing strategy may not be null");
+		}
+	}
+
+	private void assertNotNull(Class searchedClass) {
+		if(searchedClass == null){
+			throw new IllegalArgumentException("Request processing strategy class may not be null");
+		}
+	}
+}

--- a/src/main/java/org/cafesip/sipunit/processing/notify/ConferenceEventStrategy.java
+++ b/src/main/java/org/cafesip/sipunit/processing/notify/ConferenceEventStrategy.java
@@ -1,0 +1,32 @@
+package org.cafesip.sipunit.processing.notify;
+
+import org.cafesip.sipunit.SipPhone;
+import org.cafesip.sipunit.processing.RequestProcessingResult;
+import org.cafesip.sipunit.processing.RequestProcessingStrategy;
+
+import javax.sip.RequestEvent;
+import javax.sip.header.EventHeader;
+import javax.sip.message.Request;
+
+/**
+ * Checks that the received event in {@link EventHeader} is a {@value ConferenceEventStrategy#EVENT_NAME} event. If that
+ * is the case, then the receiver object will continue the event handling (i.e. this handler does not do any other
+ * processing for this event).
+ * <p>
+ * Created by TELES AG on 15/01/2018.
+ */
+public final class ConferenceEventStrategy extends RequestProcessingStrategy<SipPhone> {
+
+	private static final String EVENT_NAME = "conference";
+
+	@Override
+	public RequestProcessingResult processRequestEvent(RequestEvent requestEvent, SipPhone receiver) {
+		LOG.trace("Running " + this.getClass().getName());
+		Request request = requestEvent.getRequest();
+		EventHeader event = (EventHeader) request.getHeader(EventHeader.NAME);
+
+		// Just return so that the test can use waitRequest()
+		boolean isValid = event != null && event.getEventType().equals(EVENT_NAME);
+		return new RequestProcessingResult(isValid, isValid);
+	}
+}

--- a/src/main/java/org/cafesip/sipunit/processing/notify/PresenceEventStrategy.java
+++ b/src/main/java/org/cafesip/sipunit/processing/notify/PresenceEventStrategy.java
@@ -1,0 +1,44 @@
+package org.cafesip.sipunit.processing.notify;
+
+import org.cafesip.sipunit.PresenceSubscriber;
+import org.cafesip.sipunit.SipPhone;
+import org.cafesip.sipunit.processing.RequestProcessingResult;
+import org.cafesip.sipunit.processing.RequestProcessingStrategy;
+
+import javax.sip.RequestEvent;
+import javax.sip.header.EventHeader;
+import javax.sip.header.FromHeader;
+import javax.sip.message.Request;
+
+/**
+ * Checks that the received event in {@link EventHeader} is a {@value PresenceEventStrategy#EVENT_NAME} event. If it is,
+ * and the request targets one of the active {@link PresenceSubscriber} subscribers - then this strategy routes the
+ * event to the dedicated active subscriber object.
+ * <p>
+ * Created by TELES AG on 15/01/2018.
+ */
+public final class PresenceEventStrategy extends RequestProcessingStrategy<SipPhone> {
+
+	private static final String EVENT_NAME = "presence";
+
+	@Override
+	public RequestProcessingResult processRequestEvent(RequestEvent requestEvent, SipPhone receiver) {
+		LOG.trace("Running " + this.getClass().getName());
+		Request request = requestEvent.getRequest();
+
+		EventHeader event = (EventHeader) request.getHeader(EventHeader.NAME);
+		FromHeader from = (FromHeader) request.getHeader(FromHeader.NAME);
+
+		if (event != null && event.getEventType().equals(EVENT_NAME)) {
+			PresenceSubscriber presenceSubscriber = receiver.getBuddyInfo(from.getAddress().getURI().toString());
+			if (presenceSubscriber != null && presenceSubscriber.messageForMe(request)) {
+				presenceSubscriber.processEvent(requestEvent);
+				return new RequestProcessingResult(true, true);
+			}
+
+			return new RequestProcessingResult(true, false);
+		}
+
+		return new RequestProcessingResult(false, true);
+	}
+}

--- a/src/main/java/org/cafesip/sipunit/processing/notify/ReferEventStrategy.java
+++ b/src/main/java/org/cafesip/sipunit/processing/notify/ReferEventStrategy.java
@@ -1,0 +1,47 @@
+package org.cafesip.sipunit.processing.notify;
+
+import org.cafesip.sipunit.ReferSubscriber;
+import org.cafesip.sipunit.SipPhone;
+import org.cafesip.sipunit.processing.RequestProcessingResult;
+import org.cafesip.sipunit.processing.RequestProcessingStrategy;
+
+import javax.sip.Dialog;
+import javax.sip.RequestEvent;
+import javax.sip.header.EventHeader;
+import javax.sip.message.Request;
+import java.util.List;
+
+/**
+ * Checks that the received event in {@link EventHeader} is a {@value ReferEventStrategy#EVENT_NAME} event. If it is,
+ * and the request targets one of the active {@link ReferSubscriber} subscribers - then this strategy routes the
+ * event to the dedicated active subscriber object.
+ * <p>
+ * Created by TELES AG on 15/01/2018.
+ */
+public final class ReferEventStrategy extends RequestProcessingStrategy<SipPhone> {
+
+	private static final String EVENT_NAME = "refer";
+
+	@Override
+	public RequestProcessingResult processRequestEvent(RequestEvent requestEvent, SipPhone receiver) {
+		LOG.trace("Running " + this.getClass().getName());
+		Request request = requestEvent.getRequest();
+		Dialog dialog = requestEvent.getDialog();
+
+		EventHeader event = (EventHeader) request.getHeader(EventHeader.NAME);
+
+		if (event != null && dialog != null && event.getEventType().equals(EVENT_NAME)) {
+			List<ReferSubscriber> refers = receiver.getRefererInfoByDialog(dialog.getDialogId());
+			for (ReferSubscriber referSubscriber : refers) {
+				if (referSubscriber.messageForMe(request)) {
+					referSubscriber.processEvent(requestEvent);
+					return new RequestProcessingResult(true, true);
+				}
+			}
+
+			return new RequestProcessingResult(true, false);
+		}
+
+		return new RequestProcessingResult(false, false);
+	}
+}

--- a/src/test/java/org/cafesip/sipunit/test/misc/TestRequestProcessing.java
+++ b/src/test/java/org/cafesip/sipunit/test/misc/TestRequestProcessing.java
@@ -1,0 +1,171 @@
+package org.cafesip.sipunit.test.misc;
+
+import org.cafesip.sipunit.SipSession;
+import org.cafesip.sipunit.processing.RequestProcessingResult;
+import org.cafesip.sipunit.processing.RequestProcessingStrategy;
+import org.cafesip.sipunit.processing.RequestProcessor;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.sip.RequestEvent;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test behavior of processing processing on the configuration of {@link org.cafesip.sipunit.processing.RequestProcessingStrategy}.
+ * <p>
+ * Created by TELES AG on 12/01/2018.
+ */
+public class TestRequestProcessing {
+
+	private RequestProcessingStrategy defaultRequestProcessingStrategy = new RequestProcessingStrategy<SipSession>(false) {
+		@Override
+		public RequestProcessingResult processRequestEvent(RequestEvent requestEvent, SipSession receiver) {
+			return new RequestProcessingResult(false, false);
+		}
+	};
+
+	private RequestProcessor requestProcessor;
+
+	@Before
+	public void setUp() {
+		requestProcessor = new RequestProcessor(defaultRequestProcessingStrategy);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testShouldNotInitializeWithNull() {
+		new RequestProcessor<>((RequestProcessingStrategy<SipSession>) null);
+	}
+
+	/**
+	 * The request processor should not allow any mutation because of the immutable list
+	 */
+	@Test(expected = UnsupportedOperationException.class)
+	public void testGetStrategiesMutation() {
+		requestProcessor.getAvailableStrategies().clear();
+	}
+
+	/**
+	 * If the strategy list has only the default strategy and this strategy is attempted to be removed, the processor
+	 * should throw an exception to prevent side effects
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testRemoveLastStrategyClass() {
+		requestProcessor.remove(defaultRequestProcessingStrategy.getClass());
+	}
+
+	/**
+	 * If the strategy list has only the default strategy and this strategy is attempted to be removed, the processor
+	 * should throw an exception to prevent side effects
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void testRemoveLastStrategyInstance() {
+		requestProcessor.remove(defaultRequestProcessingStrategy);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testShouldNotAddNull() {
+		requestProcessor.add(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testShouldNotRemoveNullInstance() {
+		requestProcessor.remove((RequestProcessingStrategy) null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testShouldNotRemoveNullClass() {
+		requestProcessor.remove((Class) null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testShouldNotSearchForNullInstance() {
+		requestProcessor.contains((RequestProcessingStrategy) null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testShouldNotSearchForNullClass() {
+		requestProcessor.contains((Class) null);
+	}
+
+	@Test
+	public void testStrategiesMutation() {
+		// Attempt mutating the list obtained through the getter
+		// Should have 1 default processing strategies
+		List<RequestProcessingStrategy> requestProcessingStrategies = requestProcessor.getAvailableStrategies();
+		assertEquals(1, requestProcessingStrategies.size());
+
+		// Create a dummy strategy
+		RequestProcessingStrategy newStrategy = createMockStrategy();
+
+		// Mutate strategies through the accessor
+		requestProcessor.add(newStrategy);
+		// Returned list should be updated
+		assertEquals(2, requestProcessingStrategies.size());
+
+		List<RequestProcessingStrategy> newMatchingStrategies = requestProcessor.getAvailableStrategies();
+		assertEquals(2, newMatchingStrategies.size());
+		assertEquals(newStrategy, newMatchingStrategies.get(1));
+
+		assertTrue(requestProcessor.contains(newStrategy));
+		assertTrue(requestProcessor.contains(newStrategy.getClass()));
+
+		// Default strategy
+		assertTrue(requestProcessor.contains(defaultRequestProcessingStrategy.getClass()));
+	}
+
+	@Test
+	public void testMultipleInstancesAllowed() {
+		RequestProcessingStrategy multipleInstancesStrategy = createMockStrategy();
+
+		assertFalse(defaultRequestProcessingStrategy.multipleInstanceAllowed());
+		assertTrue(multipleInstancesStrategy.multipleInstanceAllowed());
+
+		assertEquals(1, requestProcessor.getAvailableStrategies().size());
+		assertTrue(requestProcessor.contains(defaultRequestProcessingStrategy.getClass()));
+
+		assertTrue(requestProcessor.add(multipleInstancesStrategy));
+		assertEquals(2, requestProcessor.getAvailableStrategies().size());
+
+		// Already has this strategy by now
+		assertFalse(requestProcessor.add(defaultRequestProcessingStrategy));
+		assertEquals(2, requestProcessor.getAvailableStrategies().size());
+
+		// Add a multiple instance strategy
+		assertTrue(requestProcessor.add(multipleInstancesStrategy));
+		assertEquals(3, requestProcessor.getAvailableStrategies().size());
+
+		assertTrue(requestProcessor.add(multipleInstancesStrategy));
+		assertEquals(4, requestProcessor.getAvailableStrategies().size());
+	}
+
+	@Test
+	public void testShouldConvertNullResultToFailed() {
+		RequestProcessingStrategy nullStrategy = new RequestProcessingStrategy<SipSession>() {
+			@Override
+			public RequestProcessingResult processRequestEvent(RequestEvent requestEvent, SipSession receiver) {
+				return null;
+			}
+		};
+		requestProcessor.add(nullStrategy);
+
+		RequestProcessingResult result = requestProcessor.processRequestEvent(new RequestEvent(this, null, null, null), null);
+		assertNotNull(result);
+		assertFalse(result.isProcessed());
+		assertFalse(result.isSuccessful());
+	}
+
+	private RequestProcessingStrategy createMockStrategy() {
+		return createMockStrategy(true);
+	}
+
+	private RequestProcessingStrategy createMockStrategy(boolean multipleInstancesAllowed) {
+		return new RequestProcessingStrategy<SipSession>(multipleInstancesAllowed) {
+			@Override
+			public RequestProcessingResult processRequestEvent(RequestEvent requestEvent, SipSession receiver) {
+				return new RequestProcessingResult(false, false);
+			}
+		};
+	}
+}

--- a/src/test/java/org/cafesip/sipunit/test/noproxy/TestReferNoProxy.java
+++ b/src/test/java/org/cafesip/sipunit/test/noproxy/TestReferNoProxy.java
@@ -1701,7 +1701,7 @@ public class TestReferNoProxy {
     // prepare the far end to respond to unSUBSCRIBE
     ub.processSubscribe(5000, SipResponse.OK, "OK Done");
     // send the un-SUBSCRIBE
-    assertTrue(subscription.unsubscribe(100));
+    assertTrue(subscription.unsubscribe(1000));
     assertFalse(subscription.isRemovalComplete());
     assertEquals(SipResponse.OK, subscription.getReturnCode());
     assertTrue(subscription.isSubscriptionTerminated());


### PR DESCRIPTION
The SipPhone class has a specific flow for processing NOTIFY requests:

validate request -> process if event is (conference | refer | presence | send bad request) -> else orphaned event error (call or transaction does not exist).

This flow is hard to intercept and extend via inheritance without actually copy-pasting code from the SipPhone itself. In order to avoid cumbersome inheritance of SipPhone for NOTIFY request processing, we introduce the conctept of executable NOTIFY processing strategies, which will determine if a request belongs to one of the registered EventSubscriber classes (which are not so difficultly inherited).

Thus we take inspiration from the request handling strategy solution and introduce strategies which will allow to further the spectrum of event packages which the SipPhone supports. 

This pull request does NOT provide extended set of event packages, and does not address the issue of coupling of EventSubscriber with the SipPhone parent. It is a prelude and a gateway to the end user/tester to provide their own solutions and customized event handling without actually inheriting the SipPhone itself.

[Related issue](https://github.com/RestComm/sipunit/issues/23)