### PR TITLE
Checking for second unauthorized response after authorized registration fixes #18

### DIFF
--- a/src/main/java/org/cafesip/sipunit/SipPhone.java
+++ b/src/main/java/org/cafesip/sipunit/SipPhone.java
@@ -516,6 +516,14 @@ public class SipPhone extends SipSession implements SipActionObject, RequestList
 
         response = ((ResponseEvent) response_event).getResponse();
         status_code = response.getStatusCode();
+
+        if (status_code == Response.UNAUTHORIZED) {
+          //still unauthorized -> abort registration
+          setReturnCode(status_code);
+          setErrorMessage("An unauthorized response was received from the server - even after sending registration with authorization.");
+          return null;
+        }
+
         continue;
       } else {
         setReturnCode(status_code);


### PR DESCRIPTION
Fixes endless registrations when invalid credentials are provided and the server responds with "401 Unauthorized" instead of "403 Forbidden".